### PR TITLE
Add GetADBitlockerRecoveryKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The list below shows an overview of the available methods:
 - SetADComputerDescription 
 - SetADOrganizationalUnitForComputer 
 - RemoveADComputerFromGroup 
+- GetADBitlockerRecoveryKey
 
 ## Supported Configurations
 This web service has been built to support the following versions of System Center Configuration Manager:


### PR DESCRIPTION
Added web method GetADBitlockerRecoveryKey. Allows the recovery key to be accessed for environments that are storing their keys in AD. Useful for unlocking Bitlocker'ed drives in WinPE.